### PR TITLE
Solved: Exercise 11.20

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: check the deployed app url
+        uses: jtalk/url-health-check-action@v1.2
+        with:
+          url: https://fso-pokedex.herokuapp.com/
       - name: deploy to heroku
         uses: akhileshns/heroku-deploy@v3.8.8
         if: ${{ github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip') }}
@@ -70,7 +74,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
-      - name: check the deployed app url
-        uses: jtalk/url-health-check-action@v1.2
-        with:
-          url: https://fso-pokedex.herokuapp.com/


### PR DESCRIPTION
Added URL health check step in test mode under push trigger to make
sure it is working before switching it to a scheduled trigger
ERROR: `notification on deploy success` and `notification on build
fail` returning 404 erros. Attemping to fix.